### PR TITLE
General bug fixing

### DIFF
--- a/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
+++ b/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
@@ -70,6 +70,8 @@
           <Entry value="0" text="FC 2nd Order"/> <!-- Face Centered 2nd Order -->
           <Entry value="1" text="FC 4th Order"/> <!-- Face Centered 4th Order -->
           <Entry value="2" text="OGSTM-BFM"/>    <!-- OGSTM-BFM approach -->
+          <Entry value="3" text="OGSTM-BFM2"/>   <!-- OGSTM-BFM approach -->
+          <Entry value="4" text="OGSTM-BFM4"/>   <!-- OGSTM-BFM approach -->
         </EnumerationDomain>
         <Documentation>
           Selection of the gradient computation method.

--- a/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
+++ b/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
@@ -67,8 +67,9 @@
                          number_of_elements="1"
                          panel_visibility="advanced">
         <EnumerationDomain name="enum">
-          <Entry value="0" text="FD 2nd Order"/>
-          <Entry value="1" text="FD 4th Order"/>
+          <Entry value="0" text="FC 2nd Order"/> <!-- Face Centered 2nd Order -->
+          <Entry value="1" text="FC 4th Order"/> <!-- Face Centered 4th Order -->
+          <Entry value="2" text="OGSTM-BFM"/>    <!-- OGSTM-BFM approach -->
         </EnumerationDomain>
         <Documentation>
           Selection of the gradient computation method.

--- a/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
+++ b/OGSPlugins/OGSOkuboWeiss/OGSOkuboWeiss.xml
@@ -63,7 +63,7 @@
                          label="Gradient method: "
                          command="Setgrad_type"
                          animateable="1"
-                         default_values="1"
+                         default_values="2"
                          number_of_elements="1"
                          panel_visibility="advanced">
         <EnumerationDomain name="enum">

--- a/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
+++ b/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
@@ -34,17 +34,8 @@ namespace VTK
 #include "../_utils/vtkOperations.cpp"
 }
 
-//#define INDEX(ii,jj,kk,nx,ny) ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
-//#define GETVTKVAL1(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
-//#define GETVTKVAL3(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple3((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
-//#define SETVTKVAL1(vtkarray,val,ii,jj,kk,nx,ny) ( (vtkarray)->SetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii),(val)) )
 
 vtkStandardNewMacro(vtkOGSComputeOkuboWeiss);
-
-//----------------------------------------------------------------------------
-
-
-
 
 //----------------------------------------------------------------------------
 vtkOGSComputeOkuboWeiss::vtkOGSComputeOkuboWeiss()

--- a/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
+++ b/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
@@ -12,6 +12,11 @@
 
 =========================================================================*/
 
+#include "vtkCell.h"
+#include "vtkPoints.h"
+#include "vtkCellData.h"
+#include "vtkPointData.h"
+#include "vtkFieldData.h"
 #include "vtkFloatArray.h"
 #include "vtkCellData.h"
 #include "vtkDataArraySelection.h"
@@ -23,137 +28,23 @@
 
 #include "vtkObjectFactory.h"
 
-#define INDEX(ii,jj,kk,nx,ny) ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
-#define GETVTKVAL1(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
-#define GETVTKVAL3(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple3((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
-#define SETVTKVAL1(vtkarray,val,ii,jj,kk,nx,ny) ( (vtkarray)->SetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii),(val)) )
+namespace VTK
+{
+// Include the VTK Operations
+#include "../_utils/vtkOperations.cpp"
+}
+
+//#define INDEX(ii,jj,kk,nx,ny) ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
+//#define GETVTKVAL1(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
+//#define GETVTKVAL3(vtkarray,ii,jj,kk,nx,ny)     ( (vtkarray)->GetTuple3((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii)) )
+//#define SETVTKVAL1(vtkarray,val,ii,jj,kk,nx,ny) ( (vtkarray)->SetTuple1((nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii),(val)) )
 
 vtkStandardNewMacro(vtkOGSComputeOkuboWeiss);
 
 //----------------------------------------------------------------------------
-void vtk3Grad2XY(int ii, int jj, int kk, int nx, int ny,
-	vtkFloatArray *vtkvecf, vtkFloatArray *vtkx, vtkFloatArray *vtky, double deri[4]) {
-/*
-	Second order approximation for the gradient of a vtk vectorial
-	field only in the x and y coordinates.
 
-	Input deri is in the form: [dudx, dudy, dvdx, dvdy]
-*/
-	double val[3], val1[3], cor, cor1;
 
-	// Bounds for X
-	if (ii == 0) {
-		vtkvecf->GetTuple(INDEX(ii+1,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val1);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii);  
-	} else if (ii == nx-1) {
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii-1,jj,kk,nx,ny),val1);
-		cor  = vtkx->GetTuple1(ii);
-		cor1 = vtkx->GetTuple1(ii-1);
-	} else {
-		vtkvecf->GetTuple(INDEX(ii+1,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii-1,jj,kk,nx,ny),val1);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii-1);
-	}
-	deri[0] = (val[0] - val1[0])/(cor - cor1);
-	deri[2] = (val[1] - val1[1])/(cor - cor1);
-					
-	// Bounds for y
-	if (jj == 0) {
-		vtkvecf->GetTuple(INDEX(ii,jj+1,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val1);
-		cor  = vtky->GetTuple1(jj+1);
-		cor1 = vtky->GetTuple1(jj);
-	} else if (jj == ny-1) {
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj-1,kk,nx,ny),val1);
-		cor  = vtky->GetTuple1(jj);
-		cor1 = vtky->GetTuple1(jj-1);				
-	} else {
-		vtkvecf->GetTuple(INDEX(ii,jj+1,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj-1,kk,nx,ny),val1);
-		cor  = vtky->GetTuple1(jj+1);
-		cor1 = vtky->GetTuple1(jj-1);
-	}
-	deri[1] = (val[0] - val1[0])/(cor - cor1);
-	deri[4] = (val[1] - val1[1])/(cor - cor1);
-}
 
-void vtk3Grad4XY(int ii, int jj, int kk, int nx, int ny,
-	vtkFloatArray *vtkvecf, vtkFloatArray *vtkx, vtkFloatArray *vtky, double deri[4]) {
-/*
-	Fourth order approximation for the gradient of a vtk vectorial
-	field only in the x and y coordinates.
-
-	Input deri is in the form: [dudx, dudy, dvdx, dvdy]
-*/
-	double val[3], val1[3], val2[3], val3[3], cor, cor1;
-
-	// Bounds for X
-	if (ii <= 1) {
-		vtkvecf->GetTuple(INDEX(ii+2,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii+1,jj,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val2);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii);
-
-		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2/(cor - cor1);
-		deri[2] = (-val[1] + 4*val1[1] - 3*val2[1])/2/(cor - cor1);	
-	} else if (ii >= nx-2) {
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii-1,jj,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii-2,jj,kk,nx,ny),val2);
-		cor  = vtkx->GetTuple1(ii);
-		cor1 = vtkx->GetTuple1(ii-1);
-
-		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2/(cor - cor1);
-		deri[2] = (3*val[1] - 4*val1[1] + val2[1])/2/(cor - cor1);
-	} else {
-		vtkvecf->GetTuple(INDEX(ii+2,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii+1,jj,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii-1,jj,kk,nx,ny),val2);
-		vtkvecf->GetTuple(INDEX(ii-2,jj,kk,nx,ny),val3);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii-1);
-
-		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6/(cor - cor1);
-		deri[2] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6/(cor - cor1);
-	}
-					
-	// Bounds for y
-	if (jj <= 1) {
-		vtkvecf->GetTuple(INDEX(ii,jj+2,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj+1,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val2);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii);
-
-		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2/(cor - cor1);
-		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2/(cor - cor1);	
-	} else if (jj >= ny-2) {
-		vtkvecf->GetTuple(INDEX(ii,jj,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj-1,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii,jj-2,kk,nx,ny),val2);
-		cor  = vtkx->GetTuple1(ii);
-		cor1 = vtkx->GetTuple1(ii-1);
-
-		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2/(cor - cor1);
-		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2/(cor - cor1);			
-	} else {
-		vtkvecf->GetTuple(INDEX(ii,jj+2,kk,nx,ny),val);
-		vtkvecf->GetTuple(INDEX(ii,jj+1,kk,nx,ny),val1);
-		vtkvecf->GetTuple(INDEX(ii,jj-1,kk,nx,ny),val2);
-		vtkvecf->GetTuple(INDEX(ii,jj-2,kk,nx,ny),val3);
-		cor  = vtkx->GetTuple1(ii+1);
-		cor1 = vtkx->GetTuple1(ii-1);
-
-		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6/(cor - cor1);
-		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6/(cor - cor1);
-	}
-}
 
 //----------------------------------------------------------------------------
 vtkOGSComputeOkuboWeiss::vtkOGSComputeOkuboWeiss()
@@ -187,36 +78,32 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 
 	this->UpdateProgress(0.);
 
-	// Recover XYZ coordinates
-	vtkFloatArray *vtkxcoord = vtkFloatArray::SafeDownCast(
-		input->GetXCoordinates());
-	int nx = vtkxcoord->GetNumberOfTuples();
-	vtkFloatArray *vtkycoord = vtkFloatArray::SafeDownCast(
-		input->GetYCoordinates());
-	int ny = vtkycoord->GetNumberOfTuples();
-	vtkFloatArray *vtkzcoord = vtkFloatArray::SafeDownCast(
-		input->GetZCoordinates());
-	int nz = vtkzcoord->GetNumberOfTuples();
+	// Recover XYZ number of nodes
+	int nx = input->GetXCoordinates()->GetNumberOfTuples();
+	int ny = input->GetXCoordinates()->GetNumberOfTuples();
+	int nz = input->GetXCoordinates()->GetNumberOfTuples();
+
+	// Recover weights
+	vtkFloatArray *vtke1t = vtkFloatArray::SafeDownCast(
+		input->GetCellData()->GetArray("e1t"));
+	vtkFloatArray *vtke2t = vtkFloatArray::SafeDownCast(
+		input->GetCellData()->GetArray("e2t"));
 
 	// Recover velocity vector
 	vtkFloatArray *vtkVeloc = vtkFloatArray::SafeDownCast(
 		input->GetCellData()->GetArray(this->field));
 
-	// Generate a new vtkFloatArray to store the Okubo-Weiss
-	vtkFloatArray *vtkOW = vtkFloatArray::New();
-	vtkOW->SetName("Okubo-Weiss");
-	vtkOW->SetNumberOfComponents(1);   // Scalar field
-	vtkOW->SetNumberOfTuples(nx*ny*nz);
+	// Compute the cell centers
+	vtkFloatArray *vtkCellCenters = VTK::getCellCoordinates("Cell Centers",input);
 
-	vtkFloatArray *vtkOWm = vtkFloatArray::New();
-	vtkOWm->SetName("Okubo-Weiss mask");
-	vtkOWm->SetNumberOfComponents(1);   // Scalar field
-	vtkOWm->SetNumberOfTuples(nx*ny*nz);
+	// Generate a new scalar array to store the Okubo-Weiss and the mask
+	vtkFloatArray *vtkOW  = VTK::createVTKscaf("Okubo-Weiss",nx*ny*nz,NULL);
+	vtkFloatArray *vtkOWm = VTK::createVTKscaf("Okubo-Weiss mask",nx*ny*nz,NULL);
 
 	this->UpdateProgress(0.1);
 
 	// Loop the mesh
-	double OW_mean = 0., OW_std = 0.;
+	double OW_mean = 0., sum_weights = 0., OW_std = 0.;
 
 	for (int kk = 0; kk < nz; kk++) {
 		// Computation of the Okubo-Weiss criterion at the surface
@@ -224,65 +111,78 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 			// First loop the 2D mesh and compute the gradients and mean
 			for (int jj = 0; jj < ny; jj++) {
 				for (int ii = 0; ii < nx; ii++) {
-					double deri[4];
+					double deri[9]; // We will not use the z derivatives
 					// Selection of the gradient method
 					switch (this->grad_type) {
-						case 0:
-							vtk3Grad2XY(ii,jj,kk,nx,ny,vtkVeloc,vtkxcoord,vtkycoord,deri);
+						case 0: // Second order, face centered gradient
+							    // This gradient is unsafe as it relies on the mesh projection
+							VTK::vtkGrad3XY2(ii,jj,kk,nx,ny,nz,vtkVeloc,vtkCellCenters,deri);
 							break;
-						case 1:
-							vtk3Grad4XY(ii,jj,kk,nx,ny,vtkVeloc,vtkxcoord,vtkycoord,deri);
+						case 1: // Fourth order, face centered gradient
+							    // This gradient is unsafe as it relies on the mesh projection
+							VTK::vtkGrad3XY4(ii,jj,kk,nx,ny,nz,vtkVeloc,vtkCellCenters,deri);
+							break;
+						case 2:	// OGSTM-BFM approach according to the NEMO handbook
+								// This gradient is safe as it relies on the code implementation
 							break;
 					}
 					// Rates of strain and stress
-					double Sn = (deri[1] - deri[2]);
-					double Ss = (deri[4] + deri[0]);
-					double W  = (deri[4] - deri[0]);
+					double Sn = (deri[1] - deri[3]); // dudy - dvdx
+					double Ss = (deri[4] + deri[0]); // dvdy + dudx
+					double W  = (deri[4] - deri[0]); // dvdy - dudx
 					// Compute Okubo-Weiss
 					double OW = Sn*Sn + Ss*Ss - W*W;
 					// Compute the mean
-					OW_mean += OW/nx/ny;
+					double e1t   = vtke1t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+					double e2t   = vtke2t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+					OW_mean     += OW*e1t*e2t;
+					sum_weights += e1t*e2t;
 					// Set Okubo-Weiss
-					SETVTKVAL1(vtkOW,OW,ii,jj,kk,nx,ny);
+					vtkOW->SetTuple1(VTKIND(ii,jj,kk,nx,ny),OW);
 				}
 			}
 			// Up to this point the Okubo-Weiss criterion in the surface is computed
 			// and stored in vtkOW and the mean in OW_mean.
-			//
+			OW_mean /= sum_weights;
+
 			// Now we work out the standard deviation
 			for(int jj = 0; jj < ny; jj++){
 				for (int ii = 0; ii < nx; ii++) {
-					double aux = (GETVTKVAL1(vtkOW,ii,jj,kk,nx,ny) - OW_mean);
-					OW_std += aux*aux/nx/ny;
+					double e1t = vtke1t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+					double e2t = vtke2t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+					double OW  = vtkOW->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+					OW_std    += (OW - OW_mean)*(OW - OW_mean)*e1t*e2t;
 				}
 			}
-			OW_std = this->coef*sqrt(OW_std);
+			OW_std = this->coef*sqrt(OW_std/sum_weights);
 
 			// We now have the standard deviation, let us work out the mask for
 			// the surface
 			for(int jj = 0; jj < ny; jj++){
 				for (int ii = 0; ii < nx; ii++) {
-					// Preallocate to zero
-					SETVTKVAL1(vtkOWm,0.,ii,jj,kk,nx,ny);
+					double OW  = vtkOW->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
 					// Vorticity-dominated flow
-					if (GETVTKVAL1(vtkOW,ii,jj,kk,nx,ny) < -OW_std)
-						SETVTKVAL1(vtkOWm,-1.,ii,jj,kk,nx,ny);
+					if (OW < -OW_std)
+						vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),-1.);
 					// Strain-dominated flow
-					if (GETVTKVAL1(vtkOW,ii,jj,kk,nx,ny) > OW_std)
-						SETVTKVAL1(vtkOWm,1.,ii,jj,kk,nx,ny);
+					if (OW > OW_std)
+						vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),1.);
 				}
 			}
 		// Here kk > 1, we copy the values from the surface
 		} else {
 			for(int jj = 0; jj < ny; jj++){
 				for (int ii = 0; ii < nx; ii++) {
-					SETVTKVAL1(vtkOW,GETVTKVAL1(vtkOW,ii,jj,0,nx,ny),ii,jj,kk,nx,ny);
-					SETVTKVAL1(vtkOWm,GETVTKVAL1(vtkOWm,ii,jj,0,nx,ny),ii,jj,kk,nx,ny);
+					vtkOW->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
+						vtkOW->GetTuple1(VTKIND(ii,jj,0,nx,ny)));
+					vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
+						vtkOWm->GetTuple1(VTKIND(ii,jj,0,nx,ny)));
 				}
 			}
 		}
 		this->UpdateProgress(0.1+0.8/nz*kk);
 	}
+	vtkCellCenters->Delete();
 
 	// Add arrays to input
 	input->GetCellData()->AddArray(vtkOW);  vtkOW->Delete();

--- a/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
+++ b/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
@@ -28,12 +28,14 @@
 
 #include "vtkObjectFactory.h"
 
+#ifndef vtkOperations_cpp
+#define vtkOperations_cpp
 namespace VTK
 {
 // Include the VTK Operations
 #include "../_utils/vtkOperations.cpp"
 }
-
+#endif
 
 vtkStandardNewMacro(vtkOGSComputeOkuboWeiss);
 
@@ -71,8 +73,8 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 
 	// Recover XYZ number of nodes
 	int nx = input->GetXCoordinates()->GetNumberOfTuples();
-	int ny = input->GetXCoordinates()->GetNumberOfTuples();
-	int nz = input->GetXCoordinates()->GetNumberOfTuples();
+	int ny = input->GetYCoordinates()->GetNumberOfTuples();
+	int nz = input->GetZCoordinates()->GetNumberOfTuples();
 
 	// Recover weights
 	vtkFloatArray *vtke1t = vtkFloatArray::SafeDownCast(
@@ -94,8 +96,8 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 	vtkFloatArray *vtkCellCenters = VTK::getCellCoordinates("Cell Centers",input);
 
 	// Generate a new scalar array to store the Okubo-Weiss and the mask
-	vtkFloatArray *vtkOW  = VTK::createVTKscaf("Okubo-Weiss",nx*ny*nz,NULL);
-	vtkFloatArray *vtkOWm = VTK::createVTKscaf("Okubo-Weiss mask",nx*ny*nz,NULL);
+	vtkFloatArray *vtkOW  = VTK::createVTKscaf("Okubo-Weiss",nx,ny,nz,NULL);
+	vtkFloatArray *vtkOWm = VTK::createVTKscaf("Okubo-Weiss mask",nx,ny,nz,NULL);
 
 	this->UpdateProgress(0.1);
 
@@ -103,98 +105,96 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 	double OW_mean = 0., sum_weights = 0., OW_std = 0.;
 	double deri_old[9] = {0.,0.,0.,0.,0.,0.,0.,0.,0.};
 
-	for (int kk = 0; kk < nz; kk++) {
-		// Computation of the Okubo-Weiss criterion at the surface
-		if (kk == 0) {
-			// First loop the 2D mesh and compute the gradients and mean
-			for (int jj = 0; jj < ny; jj++) {
-				for (int ii = 0; ii < nx; ii++) {
-					double deri[9] = {0.,0.,0.,0.,0.,0.,0.,0.,0.}; // We will not use the z derivatives
-					// Selection of the gradient method
-					switch (this->grad_type) {
-						case 0: // Second order, face centered gradient
-							    // This gradient is unsafe as it relies on the mesh projection
-							VTK::vtkGrad3XY2(ii,jj,kk,nx,ny,nz,vtkVeloc,vtkCellCenters,deri);
-							break;
-						case 1: // Fourth order, face centered gradient
-							    // This gradient is unsafe as it relies on the mesh projection
-							VTK::vtkGrad3XY4(ii,jj,kk,nx,ny,nz,vtkVeloc,vtkCellCenters,deri);
-							break;
-						case 2:	// OGSTM-BFM approach according to the NEMO handbook
-								// This gradient is safe as it relies on the code implementation
-							for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
-							VTK::vtkGrad3OGS1(ii,jj,kk,nx,ny,nz,
-								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
-							break;
-						case 3:	// 2nd order OGSTM-BFM approach
-								// This gradient is experimental
-							for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
-							VTK::vtkGrad3OGS2(ii,jj,kk,nx,ny,nz,
-								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
-							break;
-						case 4:	// 4th order OGSTM-BFM approach
-								// This gradient is experimental
-							for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
-							VTK::vtkGrad3OGS4(ii,jj,kk,nx,ny,nz,
-								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
-							break;
-					}
-					// Rates of strain and stress
-					double Sn = (deri[1] - deri[3]); // dudy - dvdx
-					double Ss = (deri[4] + deri[0]); // dvdy + dudx
-					double W  = (deri[4] - deri[0]); // dvdy - dudx
-					// Compute Okubo-Weiss
-					double OW = Sn*Sn + Ss*Ss - W*W;
-					// Compute the mean
-					double e1t   = vtke1t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					double e2t   = vtke2t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					OW_mean     += OW*e1t*e2t;
-					sum_weights += e1t*e2t;
-					// Set Okubo-Weiss
-					vtkOW->SetTuple1(VTKIND(ii,jj,kk,nx,ny),OW);
-				}
+	// Loop on the 2D surface mesh (k == 0) and compute the Okubo-Weiss parameter
+	for (int jj = 0; jj < ny-1; jj++) {
+		for (int ii = 0; ii < nx-1; ii++) {
+			double deri[9] = {0.,0.,0.,0.,0.,0.,0.,0.,0.}; // We will not use the z derivatives
+			// Selection of the gradient method
+			switch (this->grad_type) {
+				case 0: // Second order, face centered gradient
+						// This gradient is unsafe as it relies on the mesh projection
+					VTK::vtkGrad3XY2(ii,jj,0,nx-1,ny-1,nz-1,vtkVeloc,vtkCellCenters,deri);
+					break;
+				case 1: // Fourth order, face centered gradient
+						// This gradient is unsafe as it relies on the mesh projection
+					VTK::vtkGrad3XY4(ii,jj,0,nx-1,ny-1,nz-1,vtkVeloc,vtkCellCenters,deri);
+					break;
+				case 2:	// OGSTM-BFM approach according to the NEMO handbook
+						// This gradient is safe as it relies on the code implementation
+					for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
+					VTK::vtkGrad3OGS1(ii,jj,0,nx-1,ny-1,nz-1,
+						vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
+					break;
+				case 3:	// 2nd order OGSTM-BFM approach
+						// This gradient is experimental
+					for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
+					VTK::vtkGrad3OGS2(ii,jj,0,nx-1,ny-1,nz-1,
+						vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
+					break;
+				case 4:	// 4th order OGSTM-BFM approach
+						// This gradient is experimental
+					for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
+					VTK::vtkGrad3OGS4(ii,jj,0,nx-1,ny-1,nz-1,
+						vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
+					break;
 			}
-			// Up to this point the Okubo-Weiss criterion in the surface is computed
-			// and stored in vtkOW and the mean in OW_mean.
-			OW_mean /= sum_weights;
+			// Rates of strain and stress
+			double Sn = (deri[1] - deri[3]); // dudy - dvdx
+			double Ss = (deri[4] + deri[0]); // dvdy + dudx
+			double W  = (deri[4] - deri[0]); // dvdy - dudx
+			// Compute Okubo-Weiss
+			double OW = Sn*Sn + Ss*Ss - W*W;
+			// Compute the mean
+			double e1t   = vtke1t->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			double e2t   = vtke2t->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			OW_mean     += OW*e1t*e2t;
+			sum_weights += e1t*e2t;
+			// Set Okubo-Weiss
+			vtkOW->SetTuple1(CLLIND(ii,jj,0,nx,ny),OW);
+		}
+	}
+	// Up to this point the Okubo-Weiss criterion in the surface is computed
+	// and stored in vtkOW and the mean in OW_mean.
+	OW_mean /= sum_weights;
 
-			// Now we work out the standard deviation
-			for(int jj = 0; jj < ny; jj++){
-				for (int ii = 0; ii < nx; ii++) {
-					double e1t = vtke1t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					double e2t = vtke2t->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					double OW  = vtkOW->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					OW_std    += (OW - OW_mean)*(OW - OW_mean)*e1t*e2t;
-				}
-			}
-			OW_std = this->coef*sqrt(OW_std/sum_weights);
+	// Now we work out the standard deviation
+	for(int jj = 0; jj < ny-1; jj++){
+		for (int ii = 0; ii < nx-1; ii++) {
+			double e1t = vtke1t->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			double e2t = vtke2t->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			double OW  = vtkOW->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			OW_std    += (OW - OW_mean)*(OW - OW_mean)*e1t*e2t;
+		}
+	}
+	OW_std = this->coef*sqrt(OW_std/sum_weights);
 
-			// We now have the standard deviation, let us work out the mask for
-			// the surface
-			for(int jj = 0; jj < ny; jj++){
-				for (int ii = 0; ii < nx; ii++) {
-					double OW  = vtkOW->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-					// Vorticity-dominated flow
-					if (OW < -OW_std)
-						vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),-1.);
-					// Strain-dominated flow
-					if (OW > OW_std)
-						vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),1.);
-				}
-			}
-		// Here kk > 1, we copy the values from the surface
-		} else {
-			for(int jj = 0; jj < ny; jj++){
-				for (int ii = 0; ii < nx; ii++) {
-					vtkOW->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
-						vtkOW->GetTuple1(VTKIND(ii,jj,0,nx,ny)));
-					vtkOWm->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
-						vtkOWm->GetTuple1(VTKIND(ii,jj,0,nx,ny)));
-				}
+	// We now have the standard deviation, let us work out the mask for
+	// the surface
+	for(int jj = 0; jj < ny-1; jj++){
+		for (int ii = 0; ii < nx-1; ii++) {
+			double OW  = vtkOW->GetTuple1(CLLIND(ii,jj,0,nx,ny));
+			// Vorticity-dominated flow
+			if (OW < -OW_std)
+				vtkOWm->SetTuple1(CLLIND(ii,jj,0,nx,ny),-1.);
+			// Strain-dominated flow
+			if (OW > OW_std)
+					vtkOWm->SetTuple1(CLLIND(ii,jj,0,nx,ny),1.);
+		}
+	}	
+
+	// Now run the rest of the mesh and set the values
+	for (int kk = 0; kk < nz-1; kk++) {
+		for(int jj = 0; jj < ny-1; jj++){
+			for (int ii = 0; ii < nx-1; ii++) {
+				vtkOW->SetTuple1(CLLIND(ii,jj,kk,nx,ny),
+					vtkOW->GetTuple1(CLLIND(ii,jj,0,nx,ny)));
+				vtkOWm->SetTuple1(CLLIND(ii,jj,kk,nx,ny),
+					vtkOWm->GetTuple1(CLLIND(ii,jj,0,nx,ny)));
 			}
 		}
-		this->UpdateProgress(0.1+0.8/nz*kk);
+		this->UpdateProgress(0.1+0.8/(nz-1)*kk);
 	}
+		
 	vtkCellCenters->Delete();
 
 	// Add arrays to input

--- a/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
+++ b/OGSPlugins/OGSOkuboWeiss/vtkOGSComputeOkuboWeiss.cxx
@@ -135,6 +135,18 @@ int vtkOGSComputeOkuboWeiss::RequestData(
 							VTK::vtkGrad3OGS1(ii,jj,kk,nx,ny,nz,
 								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
 							break;
+						case 3:	// 2nd order OGSTM-BFM approach
+								// This gradient is experimental
+							for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
+							VTK::vtkGrad3OGS2(ii,jj,kk,nx,ny,nz,
+								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
+							break;
+						case 4:	// 4th order OGSTM-BFM approach
+								// This gradient is experimental
+							for (int dd = 0; dd < 9; dd++) deri_old[dd] = deri[dd];
+							VTK::vtkGrad3OGS4(ii,jj,kk,nx,ny,nz,
+								vtkVeloc,vtke1u,vtke2v,vtke3w,deri,deri_old);
+							break;
 					}
 					// Rates of strain and stress
 					double Sn = (deri[1] - deri[3]); // dudy - dvdx

--- a/OGSPlugins/OGSReader/OGSReader.xml
+++ b/OGSPlugins/OGSReader/OGSReader.xml
@@ -49,7 +49,7 @@
 
      <!-- MeshMask e1t and e2t -->
      <IntVectorProperty name="MeshMask"
-                         label="Include meshmask e1t and e2t"
+                         label="Include meshmask weights"
                          command="SetRMeshMask"
                          number_of_elements="1"
                          default_values="1"

--- a/OGSPlugins/OGSReader/vtkOGSReader.cxx
+++ b/OGSPlugins/OGSReader/vtkOGSReader.cxx
@@ -215,14 +215,24 @@ int vtkOGSReader::RequestData(vtkInformation* vtkNotUsed(request),
 	if (this->RMeshMask) {
 		double *e1t = NetCDF::readNetCDF(this->meshmask,"e1t",1*nLon*nLat);
 		double *e2t = NetCDF::readNetCDF(this->meshmask,"e2t",1*nLon*nLat);
+		double *e1u = NetCDF::readNetCDF(this->meshmask,"e1u",1*nLon*nLat);
+		double *e2v = NetCDF::readNetCDF(this->meshmask,"e2v",1*nLon*nLat);
+		double *e3w = NetCDF::readNetCDF(this->meshmask,"e3w_0",nLev*nLon*nLat);
 		// Create vtkArrays from these 2D arrays
 		vtkFloatArray *vtke1t = VTK::createVTKscaffrom2d("e1t",nLon,nLat,nLev,e1t);
 		vtkFloatArray *vtke2t = VTK::createVTKscaffrom2d("e2t",nLon,nLat,nLev,e2t);
+		vtkFloatArray *vtke1u = VTK::createVTKscaffrom2d("e1u",nLon,nLat,nLev,e1u);
+		vtkFloatArray *vtke2v = VTK::createVTKscaffrom2d("e2v",nLon,nLat,nLev,e2v);
+		vtkFloatArray *vtke3w = VTK::createVTKscaf("e3w",nLon,nLat,nLev,e3w);
 		// Add to mesh
 		this->Mesh->GetCellData()->AddArray(vtke1t);
 		this->Mesh->GetCellData()->AddArray(vtke2t);
+		this->Mesh->GetCellData()->AddArray(vtke1u);
+		this->Mesh->GetCellData()->AddArray(vtke2v);
+		this->Mesh->GetCellData()->AddArray(vtke3w);
 		vtke1t->Delete(); vtke2t->Delete();
-		free(e1t); free(e2t);
+		vtke1u->Delete(); vtke2v->Delete(); vtke3w->Delete();
+		free(e1t); free(e2t); free(e1u); free(e2v); free(e3w);
 	}
 
 	this->UpdateProgress(0.25);

--- a/OGSPlugins/OGSReader/vtkOGSReader.cxx
+++ b/OGSPlugins/OGSReader/vtkOGSReader.cxx
@@ -213,10 +213,10 @@ int vtkOGSReader::RequestData(vtkInformation* vtkNotUsed(request),
 
 	// Deal with e1t and e2t located in the meshmask
 	if (this->RMeshMask) {
-		double *e1t = NetCDF::readNetCDF(this->meshmask,"e1t",1*nLon*nLat);
-		double *e2t = NetCDF::readNetCDF(this->meshmask,"e2t",1*nLon*nLat);
-		double *e1u = NetCDF::readNetCDF(this->meshmask,"e1u",1*nLon*nLat);
-		double *e2v = NetCDF::readNetCDF(this->meshmask,"e2v",1*nLon*nLat);
+		double *e1t = NetCDF::readNetCDF(this->meshmask,"e1t",1*(nLon-1)*(nLat-1));
+		double *e2t = NetCDF::readNetCDF(this->meshmask,"e2t",1*(nLon-1)*(nLat-1));
+		double *e1u = NetCDF::readNetCDF(this->meshmask,"e1u",1*(nLon-1)*(nLat-1));
+		double *e2v = NetCDF::readNetCDF(this->meshmask,"e2v",1*(nLon-1)*(nLat-1));
 		double *e3w = NetCDF::readNetCDF(this->meshmask,"e3w_0",nLev*nLon*nLat);
 		// Create vtkArrays from these 2D arrays
 		vtkFloatArray *vtke1t = VTK::createVTKscaffrom2d("e1t",nLon,nLat,nLev,e1t);
@@ -253,15 +253,15 @@ int vtkOGSReader::RequestData(vtkInformation* vtkNotUsed(request),
 		if (this->GetAvePhysArrayStatus(varname)) {
 			// Velocity is treated separately
 			if (std::string(varname) == "Velocity") {
-				double *u = NetCDF::readNetCDF(varpath,"vozocrtx",nLon*nLat*nLev),
-					   *v = NetCDF::readNetCDF(varpath,"vomecrty",nLon*nLat*nLev),
-					   *w = NetCDF::readNetCDF(varpath,"vovecrtz",nLon*nLat*nLev);
+				double *u = NetCDF::readNetCDF(varpath,"vozocrtx",(nLon-1)*(nLat-1)*(nLev-1)),
+					   *v = NetCDF::readNetCDF(varpath,"vomecrty",(nLon-1)*(nLat-1)*(nLev-1)),
+					   *w = NetCDF::readNetCDF(varpath,"vovecrtz",(nLon-1)*(nLat-1)*(nLev-1));
 				vtkFloatArray *vtkarray = VTK::createVTKvecf3(varname,nLon,nLat,nLev,u,v,w);
 				this->Mesh->GetCellData()->AddArray(vtkarray);
 				vtkarray->Delete(); free(u); free(v); free(w);
 			}
 			else {
-				double *array = NetCDF::readNetCDF(varpath,cdfname,nLon*nLat*nLev);
+				double *array = NetCDF::readNetCDF(varpath,cdfname,(nLon-1)*(nLat-1)*(nLev-1));
 				vtkFloatArray *vtkarray = VTK::createVTKscaf(varname,nLon,nLat,nLev,array);
 				this->Mesh->GetCellData()->AddArray(vtkarray);
 				vtkarray->Delete(); free(array);
@@ -284,7 +284,7 @@ int vtkOGSReader::RequestData(vtkInformation* vtkNotUsed(request),
 			this->timeStepInfo.datetime[ii_tstep],"*");
 		// Test if the variable has been activated
 		if (this->GetAveFreqArrayStatus(varname)) {
-			double *array = NetCDF::readNetCDF(varpath,cdfname,nLon*nLat*nLev);
+			double *array = NetCDF::readNetCDF(varpath,cdfname,(nLon-1)*(nLat-1)*(nLev-1));
 			vtkFloatArray *vtkarray = VTK::createVTKscaf(varname,nLon,nLat,nLev,array);
 			this->Mesh->GetCellData()->AddArray(vtkarray);
 			vtkarray->Delete(); free(array);

--- a/OGSPlugins/OGSSelectTools/vtkOGSSelectBasin.cxx
+++ b/OGSPlugins/OGSSelectTools/vtkOGSSelectBasin.cxx
@@ -14,6 +14,7 @@
 
 #include "vtkFloatArray.h"
 #include "vtkCellData.h"
+#include "vtkPointData.h"
 #include "vtkDataArraySelection.h"
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
@@ -83,14 +84,18 @@ int vtkOGSSelectBasin::RequestData(
 	vtkUnstructuredGrid *output = vtkUnstructuredGrid::SafeDownCast(
 		outInfo->Get(vtkDataObject::DATA_OBJECT()));
 
-	// Get the number of points
-	int npoints = input->GetNumberOfPoints();
-
 	this->UpdateProgress(0.0);
 
 	// Get the basins mask
 	vtkFloatArray *basins_mask = vtkFloatArray::SafeDownCast(
 		input->GetCellData()->GetArray(this->mask_field));
+	int npoints = input->GetNumberOfCells();
+
+	if (basins_mask == NULL) {
+		vtkFloatArray *basins_mask = vtkFloatArray::SafeDownCast(
+			input->GetPointData()->GetArray(this->mask_field));
+		int npoints = input->GetNumberOfPoints();		
+	}
 
 	// Generate a new vtkFloatArray that will be used for the mask
 	vtkFloatArray *mask = vtkFloatArray::New();

--- a/OGSPlugins/OGSSelectTools/vtkOGSSelectCoast.cxx
+++ b/OGSPlugins/OGSSelectTools/vtkOGSSelectCoast.cxx
@@ -14,6 +14,7 @@
 
 #include "vtkFloatArray.h"
 #include "vtkCellData.h"
+#include "vtkPointData.h"
 #include "vtkDataArraySelection.h"
 #include "vtkInformation.h"
 #include "vtkInformationVector.h"
@@ -69,14 +70,18 @@ int vtkOGSSelectCoast::RequestData(
 	vtkUnstructuredGrid *output = vtkUnstructuredGrid::SafeDownCast(
 		outInfo->Get(vtkDataObject::DATA_OBJECT()));
 
-	// Get the number of points
-	int npoints = input->GetNumberOfPoints();
-
 	this->UpdateProgress(0.0);
 
 	// Get the basins mask
 	vtkFloatArray *coasts_mask = vtkFloatArray::SafeDownCast(
 		input->GetCellData()->GetArray(this->mask_field));
+	int npoints = input->GetNumberOfCells();
+
+	if (coasts_mask == NULL) {
+		vtkFloatArray *coasts_mask = vtkFloatArray::SafeDownCast(
+			input->GetPointData()->GetArray(this->mask_field));
+		int npoints = input->GetNumberOfPoints();	
+	}
 
 	// Generate a new vtkFloatArray that will be used for the mask
 	vtkFloatArray *mask = vtkFloatArray::New();

--- a/OGSPlugins/OGSSpatialStats/vtkOGSSpatialStats.cxx
+++ b/OGSPlugins/OGSSpatialStats/vtkOGSSpatialStats.cxx
@@ -389,6 +389,9 @@ void vtkOGSSpatialStats::PointStats(vtkDataSet *input, vtkDataSet *output, doubl
 		if (std::string(array_name) == "basins mask") continue;
 		if (std::string(array_name) == "e1t")         continue;
 		if (std::string(array_name) == "e2t")         continue;
+		if (std::string(array_name) == "e1u")         continue;
+		if (std::string(array_name) == "e2v")         continue;
+		if (std::string(array_name) == "e3w")         continue;
 
 		// Also anything not being an scalar array should not be computed
 		if (vtkVarArray->GetNumberOfComponents() > 1) {

--- a/OGSPlugins/OGSSpatialStats/vtkOGSSpatialStats.cxx
+++ b/OGSPlugins/OGSSpatialStats/vtkOGSSpatialStats.cxx
@@ -98,7 +98,6 @@ int vtkOGSSpatialStats::RequestData(vtkInformation *vtkNotUsed(request),
 	this->UpdateProgress(0.5);
 
 	// Start by dealing with any cell array
-// TODO: Implement point array
 	if (input->GetPointData()->GetNumberOfArrays() > 0)
 		this->PointStats(input,output,0.5);
 	this->UpdateProgress(1.);
@@ -164,6 +163,9 @@ void vtkOGSSpatialStats::CellStats(vtkDataSet *input, vtkDataSet *output, double
 		if (std::string(array_name) == "basins mask") continue;
 		if (std::string(array_name) == "e1t")         continue;
 		if (std::string(array_name) == "e2t")         continue;
+		if (std::string(array_name) == "e1u")         continue;
+		if (std::string(array_name) == "e2v")         continue;
+		if (std::string(array_name) == "e3w")         continue;
 
 		// Also anything not being an scalar array should not be computed
 		if (vtkVarArray->GetNumberOfComponents() > 1) {

--- a/OGSPlugins/OGSSpatialStatsFromFile/vtkOGSSpatialStatsFromFile.cxx
+++ b/OGSPlugins/OGSSpatialStatsFromFile/vtkOGSSpatialStatsFromFile.cxx
@@ -148,6 +148,9 @@ int vtkOGSSpatialStatsFromFile::RequestData(vtkInformation *vtkNotUsed(request),
 		if (std::string(coasts_mask->GetName()) == std::string(array_name)) continue;
 		if (std::string(vtke1t->GetName())      == std::string(array_name)) continue;
 		if (std::string(vtke2t->GetName())      == std::string(array_name)) continue;
+		if ("e1u"                               == std::string(array_name)) continue;
+		if ("e2v"                               == std::string(array_name)) continue;
+		if ("e3w"                               == std::string(array_name)) continue;
 
 		// At this point, we can try to load the stat profile
 		double *stat_profile = NetCDF::readNetCDF(filename, array_name, nbasins*ncoasts*nz*nstat);

--- a/OGSPlugins/_utils/OGSmesh.cpp
+++ b/OGSPlugins/_utils/OGSmesh.cpp
@@ -48,7 +48,7 @@ extern "C" void writeOGSMesh(const char *fname, int nLon, int nLat, int nLev,
 	if (fwrite(Lat2Meters,DBLSZ,nLat,myfile) != nLat) ERROR("Error writing file")
 	if (fwrite(nav_lev,DBLSZ,nLev,myfile)    != nLev) ERROR("Error writing file")
 	// Write the masks
-	int ncells = nLon*nLat*nLev;
+	int ncells = (nLon-1)*(nLat-1)*(nLev-1);
 	if (fwrite(basins_mask,DBLSZ,ncells,myfile) != ncells) ERROR("Error writing file")
 	if (fwrite(coast_mask,DBLSZ,ncells,myfile)  != ncells) ERROR("Error writing file")
 	// Close the file
@@ -85,7 +85,7 @@ extern "C" void readOGSMesh(const char *fname, int *nLon, int *nLat, int *nLev,
 	if (fread(*Lat2Meters,DBLSZ,*nLat,myfile) != (*nLat)) ERROR("Error reading file")
 	if (fread(*nav_lev,DBLSZ,*nLev,myfile)    != (*nLev)) ERROR("Error reading file")
 	// Read the masks
-	int ncells = (*nLon)*(*nLat)*(*nLev); 
+	int ncells = ((*nLon)-1)*((*nLat)-1)*((*nLev)-1); 
 	*basins_mask = (double*)malloc(ncells*DBLSZ); if (*basins_mask == NULL) ERROR("Cannot allocate memory")
 	*coast_mask  = (double*)malloc(ncells*DBLSZ); if (*coast_mask  == NULL) ERROR("Cannot allocate memory")
 	if (fread(*basins_mask,DBLSZ,ncells,myfile) != ncells) ERROR("Error reading file")

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -154,6 +154,8 @@ vtkFloatArray *createVTKscaffrom2d(const char *name, int nx, int ny, int nz, dou
 	
 	Creates a vtkFloatArray for a 3 component vector field given the array name, 
 	its dimensions in x, y, z coordinates and an additional array to fill.
+
+	This function is compliant with OGSTM-BFM code.
 */
 vtkFloatArray *createVTKvecf3(const char *name, int nx, int ny, int nz, 
 	double *a1, double *a2, double *a3) {
@@ -170,10 +172,16 @@ vtkFloatArray *createVTKvecf3(const char *name, int nx, int ny, int nz,
 		for (int kk = 0; kk < nz-1; kk++) {
 			for (int jj = 0; jj < ny-1; jj++) {
 				for (int ii = 0; ii < nx-1; ii++) {
+					// Project velocity on the staggered mesh
+					double aux_u = (ii == 0) ? a1[ARRIND(ii,jj,kk,nx,ny)] : 
+						(a1[ARRIND(ii-1,jj,kk,nx,ny)] + a1[ARRIND(ii,jj,kk,nx,ny)])/2.;
+					double aux_v = (jj == 0) ? a2[ARRIND(ii,jj,kk,nx,ny)] : 
+						(a2[ARRIND(ii,jj-1,kk,nx,ny)] + a2[ARRIND(ii,jj-1,kk,nx,ny)])/2.;
+					double aux_w = (kk == 0) ? a3[ARRIND(ii,jj,kk,nx,ny)] : 
+						(a3[ARRIND(ii,jj,kk-1,nx,ny)] + a3[ARRIND(ii,jj,kk,nx,ny)])/2.;
+					// Set array value
 					vtkArray->SetTuple3(VTKIND(ii,jj,kk,nx,ny),
-						a1[ARRIND(ii,jj,kk,nx,ny)],
-						a2[ARRIND(ii,jj,kk,nx,ny)],
-						a3[ARRIND(ii,jj,kk,nx,ny)]);
+						aux_u, aux_v, aux_w);
 				}
 			}
 		}
@@ -182,10 +190,12 @@ vtkFloatArray *createVTKvecf3(const char *name, int nx, int ny, int nz,
 	return vtkArray;
 }
 
-/* CREATEVTKSCAF
+/* CREATEVTKVECF3
 	
 	Creates a vtkFloatArray for a 3 component vector field given the array name, 
 	its dimensions and an additional array to fill.
+
+	This function is not compliant with OGSTM-BFM code.
 */
 vtkFloatArray *createVTKvecf3(const char *name, int n, double *a1, double *a2, double *a3) {
 

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -31,8 +31,8 @@
 /*
 	These macros return the index needed to iterate an array
 */
-#define VTKIND(ii,jj,kk,nx,ny)          ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
-#define ARRIND(ii,jj,kk,nx,ny)          ( (nx)*(ny)*(kk) + (nx)*(jj) + (ii) )
+#define CLLIND(ii,jj,kk,nx,ny)          ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
+#define PNTIND(ii,jj,kk,nx,ny)          ( (nx)*(ny)*(kk) + (nx)*(jj) + (ii) )
 #define STTIND(bId,cId,kk,sId,ns,nz,nc) ( ns*nz*nc*bId + ns*nz*cId + ns*kk + sId )
 
 /* CREATERECTILINEARGRID
@@ -75,7 +75,7 @@ vtkFloatArray *createVTKscaf(const char *name, int nx, int ny, int nz, double *a
 	vtkFloatArray *vtkArray = vtkFloatArray::New();
 	vtkArray->SetName(name);
 	vtkArray->SetNumberOfComponents(1); // Scalar field
-	vtkArray->SetNumberOfTuples(nx*ny*nz);
+	vtkArray->SetNumberOfTuples((nx-1)*(ny-1)*(nz-1));
 	vtkArray->Fill(0.); // Preallocate vtkArray to zero
 
 	// Fill the vtkArray with the values of the array
@@ -83,8 +83,8 @@ vtkFloatArray *createVTKscaf(const char *name, int nx, int ny, int nz, double *a
 		for (int kk = 0; kk < nz-1; kk++) {
 			for (int jj = 0; jj < ny-1; jj++) {
 				for (int ii = 0; ii < nx-1; ii++) {
-					vtkArray->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
-						array[ARRIND(ii,jj,kk,nx,ny)]);
+					vtkArray->SetTuple1(CLLIND(ii,jj,kk,nx,ny),
+						array[CLLIND(ii,jj,kk,nx,ny)]);
 				}
 			}
 		}
@@ -133,7 +133,7 @@ vtkFloatArray *createVTKscaffrom2d(const char *name, int nx, int ny, int nz, dou
 	vtkFloatArray *vtkArray = vtkFloatArray::New();
 	vtkArray->SetName(name);
 	vtkArray->SetNumberOfComponents(1); // Scalar field
-	vtkArray->SetNumberOfTuples(nx*ny*nz);
+	vtkArray->SetNumberOfTuples((nx-1)*(ny-1)*(nz-1));
 	vtkArray->Fill(0.); // Preallocate vtkArray to zero
 
 	// Fill the vtkArray with the values of the array
@@ -141,8 +141,8 @@ vtkFloatArray *createVTKscaffrom2d(const char *name, int nx, int ny, int nz, dou
 		for (int kk = 0; kk < nz-1; kk++) {
 			for (int jj = 0; jj < ny-1; jj++) {
 				for (int ii = 0; ii < nx-1; ii++) {
-					vtkArray->SetTuple1(VTKIND(ii,jj,kk,nx,ny),
-						array[ARRIND(ii,jj,0,nx,ny)]);
+					vtkArray->SetTuple1(CLLIND(ii,jj,kk,nx,ny),
+						array[CLLIND(ii,jj,0,nx,ny)]);
 				}
 			}
 		}
@@ -165,7 +165,7 @@ vtkFloatArray *createVTKvecf3(const char *name, int nx, int ny, int nz,
 	vtkFloatArray *vtkArray = vtkFloatArray::New();
 	vtkArray->SetName(name);
 	vtkArray->SetNumberOfComponents(3); // Vectorial field
-	vtkArray->SetNumberOfTuples(nx*ny*nz);
+	vtkArray->SetNumberOfTuples((nx-1)*(ny-1)*(nz-1));
 	vtkArray->Fill(0.); // Preallocate vtkArray to zero
 
 	// Fill the vtkArray with the values of the array
@@ -174,14 +174,14 @@ vtkFloatArray *createVTKvecf3(const char *name, int nx, int ny, int nz,
 			for (int jj = 0; jj < ny-1; jj++) {
 				for (int ii = 0; ii < nx-1; ii++) {
 					// Project velocity on the staggered mesh
-					double aux_u = (ii == 0) ? a1[ARRIND(ii,jj,kk,nx,ny)] : 
-						(a1[ARRIND(ii-1,jj,kk,nx,ny)] + a1[ARRIND(ii,jj,kk,nx,ny)])/2.;
-					double aux_v = (jj == 0) ? a2[ARRIND(ii,jj,kk,nx,ny)] : 
-						(a2[ARRIND(ii,jj-1,kk,nx,ny)] + a2[ARRIND(ii,jj-1,kk,nx,ny)])/2.;
-					double aux_w = (kk == 0) ? a3[ARRIND(ii,jj,kk,nx,ny)] : 
-						(a3[ARRIND(ii,jj,kk-1,nx,ny)] + a3[ARRIND(ii,jj,kk,nx,ny)])/2.;
+					double aux_u = (ii == 0) ? a1[CLLIND(ii,jj,kk,nx,ny)] : 
+						(a1[CLLIND(ii-1,jj,kk,nx,ny)] + a1[CLLIND(ii,jj,kk,nx,ny)])/2.;
+					double aux_v = (jj == 0) ? a2[CLLIND(ii,jj,kk,nx,ny)] : 
+						(a2[CLLIND(ii,jj-1,kk,nx,ny)] + a2[CLLIND(ii,jj-1,kk,nx,ny)])/2.;
+					double aux_w = (kk == 0) ? a3[CLLIND(ii,jj,kk,nx,ny)] : 
+						(a3[CLLIND(ii,jj,kk-1,nx,ny)] + a3[CLLIND(ii,jj,kk,nx,ny)])/2.;
 					// Set array value
-					vtkArray->SetTuple3(VTKIND(ii,jj,kk,nx,ny),
+					vtkArray->SetTuple3(CLLIND(ii,jj,kk,nx,ny),
 						aux_u, aux_v, aux_w);
 				}
 			}
@@ -367,14 +367,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == 0) {
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (ii == nx-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -388,14 +388,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == 0) {
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (jj == ny-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -409,14 +409,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == 0) {
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (kk == nz-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -445,32 +445,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[0] - xyz1[0]);  // dudx
 		deri[3] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[0] - xyz1[0]);  // dvdx
 		deri[6] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[0] - xyz1[0]);  // dwdx
 	} else if (ii >= nx-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny)  , val2);
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny)  , val2);
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), xyz1);
 
 		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[0] - xyz1[0]); // dudx
 		deri[3] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[0] - xyz1[0]); // dvdx
 		deri[6] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[0] - xyz1[0]); // dwdx
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny)  , val2);
-		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny)  , val3);
-		vtkpoints->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny)  , val3);
+		vtkpoints->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), xyz1);
 
 		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[0] - xyz1[0]); // dudx
 		deri[3] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[0] - xyz1[0]); // dvdx
@@ -481,32 +481,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[1] - xyz1[1]); // dvdy
 		deri[7] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[1] - xyz1[1]); // dwdy
 	} else if (jj >= ny-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny)  , val2);
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny)  , val2);
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), xyz1);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[1] - xyz1[1]); // dvdy
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[1] - xyz1[1]); // dwdy
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny)  , val2);
-		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny)  , val3);
-		vtkpoints->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny)  , val3);
+		vtkpoints->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), xyz1);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[1] - xyz1[1]); // dvdy
@@ -517,32 +517,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[2] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[2] - xyz1[2]); // dudz
 		deri[5] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[2] - xyz1[2]); // dvdz
 		deri[8] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[2] - xyz1[2]); // dwdz
 	} else if (kk >= nz-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny)  , val2);
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny)  , val2);
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), xyz1);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[2] - xyz1[2]); // dudz
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[2] - xyz1[2]); // dvdz
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[2] - xyz1[2]); // dwdz
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny)  , val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny)  , val2);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny)  , val3);
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), xyz );
-		vtkpoints->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), xyz1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny)  , val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny)  , val3);
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), xyz );
+		vtkpoints->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), xyz1);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[2] - xyz1[2]); // dudz
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[2] - xyz1[2]); // dvdz
@@ -573,19 +573,19 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == nx-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); 
-		ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); 
+		ind1 = CLLIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); 
-		ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); 
+		ind1 = CLLIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -602,11 +602,11 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == ny-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); 
-		ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); 
+		ind1 = CLLIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); 
-		ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); 
+		ind1 = CLLIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -623,11 +623,11 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == nz-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); 
-		ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); 
+		ind1 = CLLIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); 
-		ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); 
+		ind1 = CLLIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -666,19 +666,19 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == 0) {
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (ii == nx-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
 		e1u *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -696,11 +696,11 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == 0) {
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (jj == ny-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
 		e2v *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -718,11 +718,11 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == 0) {
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
 	} else if (kk == nz-1) {
-		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
 		e3w *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -761,34 +761,34 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3], val2[3], val3[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e1u;  // dudx
 		deri[3] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e1u;  // dvdx
 		deri[6] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e1u;  // dwdx
 	} else if (ii >= nx-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny), val2);
 
 		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2./e1u; // dudx
 		deri[3] = (3*val[1] - 4*val1[1] + val2[1])/2./e1u; // dvdx
 		deri[6] = (3*val[2] - 4*val1[2] + val2[2])/2./e1u; // dwdx
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), val2);
-		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny), val3);
+		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny), val3);
 
 		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e1u; // dudx
 		deri[3] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e1u; // dvdx
@@ -803,26 +803,26 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e2v; // dudy
 		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e2v; // dvdy
 		deri[7] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e2v; // dwdy
 	} else if (jj >= ny-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny), val2);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e2v; // dudy
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e2v; // dvdy
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e2v; // dwdy
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), val2);
-		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny), val3);
+		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny), val3);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e2v; // dudy
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e2v; // dvdy
@@ -837,26 +837,26 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk <= 1) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[2] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e3w; // dudz
 		deri[5] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e3w; // dvdz
 		deri[8] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e3w; // dwdz
 	} else if (kk >= nz-2) {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny), val2);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e3w; // dudz
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e3w; // dvdz
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e3w; // dwdz
 	} else {
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny), val );
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), val1);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), val2);
-		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny), val3);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), val2);
+		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny), val3);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e3w; // dudz
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e3w; // dvdz

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -367,14 +367,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == 0) {
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (ii == nx-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -388,14 +388,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == 0) {
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (jj == ny-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -409,14 +409,14 @@ void vtkGrad3XY2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == 0) {
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (kk == nz-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
@@ -445,32 +445,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(PNTIND(ii+2,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii+1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(PNTIND(ii+1,jj,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[0] - xyz1[0]);  // dudx
 		deri[3] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[0] - xyz1[0]);  // dvdx
 		deri[6] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[0] - xyz1[0]);  // dwdx
 	} else if (ii >= nx-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny)  , val2);
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(PNTIND(ii-1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii-2,jj,kk,nx,ny)  , val2);
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(PNTIND(ii-1,jj,kk,nx,ny), xyz1);
 
 		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[0] - xyz1[0]); // dudx
 		deri[3] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[0] - xyz1[0]); // dvdx
 		deri[6] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[0] - xyz1[0]); // dwdx
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny)  , val2);
-		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny)  , val3);
-		vtkpoints->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii+2,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii+1,jj,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii-1,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii-2,jj,kk,nx,ny)  , val3);
+		vtkpoints->GetTuple(PNTIND(ii+1,jj,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii-1,jj,kk,nx,ny), xyz1);
 
 		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[0] - xyz1[0]); // dudx
 		deri[3] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[0] - xyz1[0]); // dvdx
@@ -481,32 +481,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj+2,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj+1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(PNTIND(ii,jj+1,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[1] - xyz1[1]); // dvdy
 		deri[7] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[1] - xyz1[1]); // dwdy
 	} else if (jj >= ny-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny)  , val2);
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj-1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj-2,kk,nx,ny)  , val2);
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj-1,kk,nx,ny), xyz1);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[1] - xyz1[1]); // dvdy
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[1] - xyz1[1]); // dwdy
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny)  , val2);
-		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny)  , val3);
-		vtkpoints->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj+2,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj+1,kk,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj-1,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj-2,kk,nx,ny)  , val3);
+		vtkpoints->GetTuple(PNTIND(ii,jj+1,kk,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj-1,kk,nx,ny), xyz1);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[1] - xyz1[1]); // dudy
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[1] - xyz1[1]); // dvdy
@@ -517,32 +517,32 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val2);
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+2,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+1,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val2);
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk+1,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz1);
 		
 		deri[2] = (-val[0] + 4*val1[0] - 3*val2[0])/2./(xyz[2] - xyz1[2]); // dudz
 		deri[5] = (-val[1] + 4*val1[1] - 3*val2[1])/2./(xyz[2] - xyz1[2]); // dvdz
 		deri[8] = (-val[2] + 4*val1[2] - 3*val2[2])/2./(xyz[2] - xyz1[2]); // dwdz
 	} else if (kk >= nz-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)    , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny)  , val2);
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)    , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-1,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-2,nx,ny)  , val2);
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk-1,nx,ny), xyz1);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./(xyz[2] - xyz1[2]); // dudz
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./(xyz[2] - xyz1[2]); // dvdz
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./(xyz[2] - xyz1[2]); // dwdz
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny)  , val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny)  , val2);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny)  , val3);
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), xyz );
-		vtkpoints->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), xyz1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+2,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+1,nx,ny)  , val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-1,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-2,nx,ny)  , val3);
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk+1,nx,ny), xyz );
+		vtkpoints->GetTuple(PNTIND(ii,jj,kk-1,nx,ny), xyz1);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/6./(xyz[2] - xyz1[2]); // dudz
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/6./(xyz[2] - xyz1[2]); // dvdz
@@ -573,19 +573,19 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == nx-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); 
-		ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); 
+		ind1 = PNTIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); 
-		ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); 
+		ind1 = PNTIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -602,11 +602,11 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == ny-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); 
-		ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); 
+		ind1 = PNTIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); 
-		ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); 
+		ind1 = PNTIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -623,11 +623,11 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == nz-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); 
-		ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); 
+		ind1 = PNTIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); 
-		ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); 
+		ind1 = PNTIND(ii,jj,kk,nx,ny);
 	}
 	// Recover values from vtkArrays
 	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
@@ -666,19 +666,19 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii == 0) {
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (ii == nx-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii+1,jj,kk,nx,ny); ind1 = CLLIND(ii-1,jj,kk,nx,ny);
+		ind  = PNTIND(ii+1,jj,kk,nx,ny); ind1 = PNTIND(ii-1,jj,kk,nx,ny);
 		e1u *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -696,11 +696,11 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj == 0) {
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (jj == ny-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj+1,kk,nx,ny); ind1 = CLLIND(ii,jj-1,kk,nx,ny);
+		ind  = PNTIND(ii,jj+1,kk,nx,ny); ind1 = PNTIND(ii,jj-1,kk,nx,ny);
 		e2v *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -718,11 +718,11 @@ void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk == 0) {
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk,nx,ny);
 	} else if (kk == nz-1) {
-		ind  = CLLIND(ii,jj,kk,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
 	} else {
-		ind  = CLLIND(ii,jj,kk+1,nx,ny); ind1 = CLLIND(ii,jj,kk-1,nx,ny);
+		ind  = PNTIND(ii,jj,kk+1,nx,ny); ind1 = PNTIND(ii,jj,kk-1,nx,ny);
 		e3w *= 2.;
 	}
 	// Recover values from vtkArrays
@@ -761,34 +761,34 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 	double val[3], val1[3], val2[3], val3[3];
 
 	// Recover e1u, e2v and e3w
-	double e1u = vtke1u->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e2v = vtke2v->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
-	double e3w = vtke3w->GetTuple1(CLLIND(ii,jj,kk,nx,ny));
+	double e1u = vtke1u->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(PNTIND(ii,jj,kk,nx,ny));
 
 	/*
 		DERIVATIVES WITH RESPECT TO X
 	*/
 	if (ii <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e1u;  // dudx
 		deri[3] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e1u;  // dvdx
 		deri[6] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e1u;  // dwdx
 	} else if (ii >= nx-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii-1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii-2,jj,kk,nx,ny), val2);
 
 		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2./e1u; // dudx
 		deri[3] = (3*val[1] - 4*val1[1] + val2[1])/2./e1u; // dvdx
 		deri[6] = (3*val[2] - 4*val1[2] + val2[2])/2./e1u; // dwdx
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii+2,jj,kk,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii+1,jj,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii-1,jj,kk,nx,ny), val2);
-		vtkvecf->GetTuple(CLLIND(ii-2,jj,kk,nx,ny), val3);
+		vtkvecf->GetTuple(PNTIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii-1,jj,kk,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii-2,jj,kk,nx,ny), val3);
 
 		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e1u; // dudx
 		deri[3] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e1u; // dvdx
@@ -803,26 +803,26 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Y
 	*/
 	if (jj <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e2v; // dudy
 		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e2v; // dvdy
 		deri[7] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e2v; // dwdy
 	} else if (jj >= ny-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj-1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj-2,kk,nx,ny), val2);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e2v; // dudy
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e2v; // dvdy
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e2v; // dwdy
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii,jj+2,kk,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii,jj+1,kk,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj-1,kk,nx,ny), val2);
-		vtkvecf->GetTuple(CLLIND(ii,jj-2,kk,nx,ny), val3);
+		vtkvecf->GetTuple(PNTIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj-1,kk,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj-2,kk,nx,ny), val3);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e2v; // dudy
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e2v; // dvdy
@@ -837,26 +837,26 @@ void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
 		DERIVATIVES WITH RESPECT TO Z
 	*/
 	if (kk <= 1) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val2);
 		
 		deri[2] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e3w; // dudz
 		deri[5] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e3w; // dvdz
 		deri[8] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e3w; // dwdz
 	} else if (kk >= nz-2) {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk,nx,ny)  , val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-1,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-2,nx,ny), val2);
 
 		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e3w; // dudz
 		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e3w; // dvdz
 		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e3w; // dwdz
 	} else {
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+2,nx,ny), val );
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk+1,nx,ny), val1);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-1,nx,ny), val2);
-		vtkvecf->GetTuple(CLLIND(ii,jj,kk-2,nx,ny), val3);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-1,nx,ny), val2);
+		vtkvecf->GetTuple(PNTIND(ii,jj,kk-2,nx,ny), val3);
 
 		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e3w; // dudz
 		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e3w; // dvdz

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -640,3 +640,230 @@ void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
 	deri[5] = (ii == 0) ? deri[5] : (deri[5] + deri_old[5])/2.;
 	deri[8] = (ii == 0) ? deri[8] : (deri[8] + deri_old[8])/2.;
 }
+
+/* VTKGRAD3OGS2
+
+	Second order, face centered, approximation of the gradient for
+	a vtk vectorial field using OGSTM-BFM approach.
+
+	This gradient lives in the staggered mesh. 
+
+	The input is assumed to be on the cell centered mesh. 
+
+	The output is returned on the cell centered mesh.
+
+	This gradient method is experimental
+
+	Output deri is in the form: [dudx, dudy, dudz, 
+	                             dvdx, dvdy, dvdz, 
+	                             dwdx, dwdy, dwdz]
+*/
+void vtkGrad3OGS2(int ii, int jj, int kk, int nx, int ny, int nz,
+	vtkFloatArray *vtkvecf, vtkFloatArray *vtke1u, vtkFloatArray *vtke2v, vtkFloatArray *vtke3w, 
+	double deri[9], double deri_old[9]) {
+
+	int ind = 0, ind1 = 0;
+	double val[3], val1[3];
+
+	// Recover e1u, e2v and e3w
+	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+
+	/*
+		DERIVATIVES WITH RESPECT TO X
+	*/
+	if (ii == 0) {
+		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+	} else if (ii == nx-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+	} else {
+		ind  = VTKIND(ii+1,jj,kk,nx,ny); ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+		e1u *= 2.;
+	}
+	// Recover values from vtkArrays
+	vtkvecf->GetTuple(ind,val); vtkvecf->GetTuple(ind1,val1);
+	// Compute the derivatives with respect to x
+	deri[0] = (val[0] - val1[0])/e1u; // dudx
+	deri[3] = (val[1] - val1[1])/e1u; // dvdx
+	deri[6] = (val[2] - val1[2])/e1u; // dwdx
+	// Interpolate on the centered grid
+	deri[0] = (ii == 0) ? deri[0] : (deri[0] + deri_old[0])/2.;
+	deri[3] = (ii == 0) ? deri[3] : (deri[3] + deri_old[3])/2.;
+	deri[6] = (ii == 0) ? deri[6] : (deri[6] + deri_old[6])/2.;
+
+	/*
+		DERIVATIVES WITH RESPECT TO Y
+	*/
+	if (jj == 0) {
+		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+	} else if (jj == ny-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+	} else {
+		ind  = VTKIND(ii,jj+1,kk,nx,ny); ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+		e2v *= 2.;
+	}
+	// Recover values from vtkArrays
+	vtkvecf->GetTuple(ind,val); vtkvecf->GetTuple(ind1,val1);
+	// Compute the derivatives with respect to x
+	deri[1] = (val[0] - val1[0])/e2v; // dudy
+	deri[4] = (val[1] - val1[1])/e2v; // dvdy
+	deri[7] = (val[2] - val1[2])/e2v; // dwdy
+	// Interpolate on the centered grid
+	deri[1] = (ii == 0) ? deri[1] : (deri[1] + deri_old[1])/2.;
+	deri[4] = (ii == 0) ? deri[4] : (deri[4] + deri_old[4])/2.;
+	deri[7] = (ii == 0) ? deri[7] : (deri[7] + deri_old[7])/2.;
+
+	/*
+		DERIVATIVES WITH RESPECT TO Z
+	*/
+	if (kk == 0) {
+		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk,nx,ny);
+	} else if (kk == nz-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+	} else {
+		ind  = VTKIND(ii,jj,kk+1,nx,ny); ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+		e3w *= 2.;
+	}
+	// Recover values from vtkArrays
+	vtkvecf  ->GetTuple(ind,val); vtkvecf  ->GetTuple(ind1,val1);
+	// Compute the derivatives with respect to x
+	deri[2] = (val[0] - val1[0])/e3w;  // dudz
+	deri[5] = (val[1] - val1[1])/e3w;  // dvdz
+	deri[8] = (val[2] - val1[2])/e3w;  // dwdz
+	// Interpolate on the centered grid
+	deri[2] = (ii == 0) ? deri[2] : (deri[2] + deri_old[2])/2.;
+	deri[5] = (ii == 0) ? deri[5] : (deri[5] + deri_old[5])/2.;
+	deri[8] = (ii == 0) ? deri[8] : (deri[8] + deri_old[8])/2.;
+}
+
+/* VTKGRAD3OGS4
+
+	Fourth order, face centered, approximation of the gradient for
+	a vtk vectorial field using OGSTM-BFM approach.
+
+	This gradient lives in the staggered mesh. 
+
+	The input is assumed to be on the cell centered mesh. 
+
+	The output is returned on the cell centered mesh.
+
+	This gradient method is experimental
+
+	Output deri is in the form: [dudx, dudy, dudz, 
+	                             dvdx, dvdy, dvdz, 
+	                             dwdx, dwdy, dwdz]
+*/
+void vtkGrad3OGS4(int ii, int jj, int kk, int nx, int ny, int nz,
+	vtkFloatArray *vtkvecf, vtkFloatArray *vtke1u, vtkFloatArray *vtke2v, vtkFloatArray *vtke3w, 
+	double deri[9], double deri_old[9]) {
+
+	double val[3], val1[3], val2[3], val3[3];
+
+	// Recover e1u, e2v and e3w
+	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+
+	/*
+		DERIVATIVES WITH RESPECT TO X
+	*/
+	if (ii <= 1) {
+		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		
+		deri[0] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e1u;  // dudx
+		deri[3] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e1u;  // dvdx
+		deri[6] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e1u;  // dwdx
+	} else if (ii >= nx-2) {
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny), val2);
+
+		deri[0] = (3*val[0] - 4*val1[0] + val2[0])/2./e1u; // dudx
+		deri[3] = (3*val[1] - 4*val1[1] + val2[1])/2./e1u; // dvdx
+		deri[6] = (3*val[2] - 4*val1[2] + val2[2])/2./e1u; // dwdx
+	} else {
+		vtkvecf->GetTuple(VTKIND(ii+2,jj,kk,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii+1,jj,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii-1,jj,kk,nx,ny), val2);
+		vtkvecf->GetTuple(VTKIND(ii-2,jj,kk,nx,ny), val3);
+
+		deri[0] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e1u; // dudx
+		deri[3] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e1u; // dvdx
+		deri[6] = (-val[2] + 8*val1[2] - 8*val2[2] + val3[2])/12./e1u; // dwdx
+	}
+	// Interpolate on the centered grid
+	deri[0] = (ii == 0) ? deri[0] : (deri[0] + deri_old[0])/2.;
+	deri[3] = (ii == 0) ? deri[3] : (deri[3] + deri_old[3])/2.;
+	deri[6] = (ii == 0) ? deri[6] : (deri[6] + deri_old[6])/2.;
+					
+	/*
+		DERIVATIVES WITH RESPECT TO Y
+	*/
+	if (jj <= 1) {
+		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		
+		deri[1] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e2v; // dudy
+		deri[4] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e2v; // dvdy
+		deri[7] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e2v; // dwdy
+	} else if (jj >= ny-2) {
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny), val2);
+
+		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e2v; // dudy
+		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e2v; // dvdy
+		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e2v; // dwdy
+	} else {
+		vtkvecf->GetTuple(VTKIND(ii,jj+2,kk,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii,jj+1,kk,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj-1,kk,nx,ny), val2);
+		vtkvecf->GetTuple(VTKIND(ii,jj-2,kk,nx,ny), val3);
+
+		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e2v; // dudy
+		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e2v; // dvdy
+		deri[7] = (-val[2] + 8*val1[2] - 8*val2[2] + val3[2])/12./e2v; // dwdy
+	}
+	// Interpolate on the centered grid
+	deri[1] = (ii == 0) ? deri[1] : (deri[1] + deri_old[1])/2.;
+	deri[4] = (ii == 0) ? deri[4] : (deri[4] + deri_old[4])/2.;
+	deri[7] = (ii == 0) ? deri[7] : (deri[7] + deri_old[7])/2.;
+
+	/*
+		DERIVATIVES WITH RESPECT TO Z
+	*/
+	if (kk <= 1) {
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val2);
+		
+		deri[2] = (-val[0] + 4*val1[0] - 3*val2[0])/2./e3w; // dudz
+		deri[5] = (-val[1] + 4*val1[1] - 3*val2[1])/2./e3w; // dvdz
+		deri[8] = (-val[2] + 4*val1[2] - 3*val2[2])/2./e3w; // dwdz
+	} else if (kk >= nz-2) {
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk,nx,ny)  , val );
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny), val2);
+
+		deri[1] = (3*val[0] - 4*val1[0] + val2[0])/2./e3w; // dudz
+		deri[4] = (3*val[1] - 4*val1[1] + val2[1])/2./e3w; // dvdz
+		deri[7] = (3*val[2] - 4*val1[2] + val2[2])/2./e3w; // dwdz
+	} else {
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk+2,nx,ny), val );
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk+1,nx,ny), val1);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk-1,nx,ny), val2);
+		vtkvecf->GetTuple(VTKIND(ii,jj,kk-2,nx,ny), val3);
+
+		deri[1] = (-val[0] + 8*val1[0] - 8*val2[0] + val3[0])/12./e3w; // dudz
+		deri[4] = (-val[1] + 8*val1[1] - 8*val2[1] + val3[1])/12./e3w; // dvdz
+		deri[7] = (-val[2] + 8*val1[2] - 8*val2[2] + val3[2])/12./e3w; // dwdz
+	}
+	// Interpolate on the centered grid
+	deri[2] = (ii == 0) ? deri[2] : (deri[2] + deri_old[2])/2.;
+	deri[5] = (ii == 0) ? deri[5] : (deri[5] + deri_old[5])/2.;
+	deri[8] = (ii == 0) ? deri[8] : (deri[8] + deri_old[8])/2.;
+}

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -550,3 +550,93 @@ void vtkGrad3XY4(int ii, int jj, int kk, int nx, int ny, int nz,
 	}
 }
 
+/* VTKGRAD3OGS1
+
+	First order, forward Euler, approximation of the gradient for
+	a vtk vectorial field using OGSTM-BFM approach.
+
+	This gradient lives in the staggered mesh. 
+
+	The input is assumed to be on the cell centered mesh. 
+
+	The output is returned on the cell centered mesh.
+
+	Output deri is in the form: [dudx, dudy, dudz, 
+	                             dvdx, dvdy, dvdz, 
+	                             dwdx, dwdy, dwdz]
+*/
+void vtkGrad3OGS1(int ii, int jj, int kk, int nx, int ny, int nz,
+	vtkFloatArray *vtkvecf, vtkFloatArray *vtke1u, vtkFloatArray *vtke2v, vtkFloatArray *vtke3w, 
+	double deri[9], double deri_old[9]) {
+
+	int ind = 0, ind1 = 0;
+	double val[3], val1[3];
+
+	// Recover e1u, e2v and e3w
+	double e1u = vtke1u->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e2v = vtke2v->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+	double e3w = vtke3w->GetTuple1(VTKIND(ii,jj,kk,nx,ny));
+
+	/*
+		DERIVATIVES WITH RESPECT TO X
+	*/
+	if (ii == nx-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); 
+		ind1 = VTKIND(ii-1,jj,kk,nx,ny);
+	} else {
+		ind  = VTKIND(ii+1,jj,kk,nx,ny); 
+		ind1 = VTKIND(ii,jj,kk,nx,ny);
+	}
+	// Recover values from vtkArrays
+	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
+	// Compute the derivatives
+	deri[0] = (val[0] - val1[0])/e1u; // dudx
+	deri[3] = (val[1] - val1[1])/e1u; // dvdx
+	deri[6] = (val[2] - val1[2])/e1u; // dwdx
+	// Interpolate on the centered grid
+	deri[0] = (ii == 0) ? deri[0] : (deri[0] + deri_old[0])/2.;
+	deri[3] = (ii == 0) ? deri[3] : (deri[3] + deri_old[3])/2.;
+	deri[6] = (ii == 0) ? deri[6] : (deri[6] + deri_old[6])/2.;
+
+	/*
+		DERIVATIVES WITH RESPECT TO Y
+	*/
+	if (jj == ny-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); 
+		ind1 = VTKIND(ii,jj-1,kk,nx,ny);
+	} else {
+		ind  = VTKIND(ii,jj+1,kk,nx,ny); 
+		ind1 = VTKIND(ii,jj,kk,nx,ny);
+	}
+	// Recover values from vtkArrays
+	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
+	// Compute the derivatives
+	deri[1] = (val[0] - val1[0])/e2v; // dudy
+	deri[4] = (val[1] - val1[1])/e2v; // dvdy
+	deri[7] = (val[2] - val1[2])/e2v; // dwdy
+	// Interpolate on the centered grid
+	deri[1] = (ii == 0) ? deri[1] : (deri[1] + deri_old[1])/2.;
+	deri[4] = (ii == 0) ? deri[4] : (deri[4] + deri_old[4])/2.;
+	deri[7] = (ii == 0) ? deri[7] : (deri[7] + deri_old[7])/2.;
+
+	/*
+		DERIVATIVES WITH RESPECT TO Z
+	*/
+	if (kk == nz-1) {
+		ind  = VTKIND(ii,jj,kk,nx,ny); 
+		ind1 = VTKIND(ii,jj,kk-1,nx,ny);
+	} else {
+		ind  = VTKIND(ii,jj,kk+1,nx,ny); 
+		ind1 = VTKIND(ii,jj,kk,nx,ny);
+	}
+	// Recover values from vtkArrays
+	vtkvecf->GetTuple(ind,val);  vtkvecf->GetTuple(ind1,val1);
+	// Compute the derivatives
+	deri[2] = (val[0] - val1[0])/e3w; // dudz
+	deri[5] = (val[1] - val1[1])/e3w; // dvdz
+	deri[8] = (val[2] - val1[2])/e3w; // dwdz
+	// Interpolate on the centered grid
+	deri[2] = (ii == 0) ? deri[2] : (deri[2] + deri_old[2])/2.;
+	deri[5] = (ii == 0) ? deri[5] : (deri[5] + deri_old[5])/2.;
+	deri[8] = (ii == 0) ? deri[8] : (deri[8] + deri_old[8])/2.;
+}

--- a/OGSPlugins/_utils/vtkOperations.cpp
+++ b/OGSPlugins/_utils/vtkOperations.cpp
@@ -33,7 +33,7 @@
 */
 #define CLLIND(ii,jj,kk,nx,ny)          ( (nx-1)*(ny-1)*(kk) + (nx-1)*(jj) + (ii) )
 #define PNTIND(ii,jj,kk,nx,ny)          ( (nx)*(ny)*(kk) + (nx)*(jj) + (ii) )
-#define STTIND(bId,cId,kk,sId,ns,nz,nc) ( ns*nz*nc*bId + ns*nz*cId + ns*kk + sId )
+#define STTIND(bId,cId,kk,sId,ns,nz,nc) ( (ns)*(nz)*(nc)*(bId) + (ns)*(nz)*(cId) + (ns)*(kk) + (sId) )
 
 /* CREATERECTILINEARGRID
 


### PR DESCRIPTION
There was a big bug in how the mesh was being generated. ParaView was treating the cell centers of OGSTM-BFM as points for the rectilinear grid. This issue has been solved and all the plugins have been adapted to this new mesh.

Another bug was on the OkuboWeiss, where ny and nz were computed using the x coordinate. This one has been addressed as well.

The code has been tested and it is free of bugs at the moment.