### PR TITLE
Fixed issues and reworked OGSAnnotateDateTime

### DIFF
--- a/OGSPlugins/OGSAnnotateDateTime/CMakeLists.txt
+++ b/OGSPlugins/OGSAnnotateDateTime/CMakeLists.txt
@@ -22,5 +22,6 @@ endif()
 
 ADD_PARAVIEW_PLUGIN(OGSAnnotateDateTime "1.0"
   SERVER_MANAGER_XML OGSAnnotateDateTime.xml
+  SERVER_MANAGER_SOURCES vtkOGSAnnotateDateTime.cxx
   REQUIRED_ON_SERVER
   )

--- a/OGSPlugins/OGSAnnotateDateTime/OGSAnnotateDateTime.xml
+++ b/OGSPlugins/OGSAnnotateDateTime/OGSAnnotateDateTime.xml
@@ -1,54 +1,66 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
-    <SourceProxy class="vtkPythonAnnotationFilter"
-                 label="OGS Annotate Date and Time"
-                 name="OGSAnnotateDateTime">
+      <SourceProxy class="vtkOGSAnnotateDateTime"
+                   label="OGS Annotate Date and Time"
+                   name="OGSAnnotateDateTime">
       <Documentation long_help="This filter writes the date and time for an OGS reader"
                      short_help="Writes the date and time for an OGS reader">
                      This filter uses Python to write the date and time for an OGS reader.
-                   </Documentation>
-      <InputProperty clean_command="RemoveAllInputs"
-                     command="AddInputConnection"
-                     multiple_input="1"
+      </Documentation>
+      <InputProperty command="SetInputConnection"
                      name="Input">
         <ProxyGroupDomain name="groups">
           <Group name="sources" />
           <Group name="filters" />
         </ProxyGroupDomain>
-        <DataTypeDomain name="input_type">
-          <DataType value="vtkDataObject" />
-        </DataTypeDomain>
-        <Documentation>Set the input of the filter.</Documentation>
+        <Documentation>This property specifies the input dataset for which to
+        display the time.</Documentation>
       </InputProperty>
-      <IntVectorProperty command="SetArrayAssociation"
-                         default_values="2"
-                         name="ArrayAssociation"
-                         panel_visibility="advanced"
-                         number_of_elements="1">
-        <Documentation>Select the attribute to use to popular array names from.</Documentation>
-        <EnumerationDomain name="enum">
-          <Entry text="Point Data" value="0" />
-          <Entry text="Cell Data" value="1" />
-          <Entry text="Field Data" value="2" />
-          <Entry text="Row Data" value="6" />
-        </EnumerationDomain>
-      </IntVectorProperty>
-      <StringVectorProperty command="SetExpression"
-                            name="Expression"
-                            panel_visibility="advanced"
-                            default_values="'Date: %s' % ( Date.GetValue(0) )"
-                            number_of_elements="1">
-        <Documentation>The Python expression evaluated during execution.
-        FieldData arrays are direclty available through their name. Set of
-        provided variables [input, t_value, t_steps, t_range, t_index,
-        FieldData, PointData, CellData] (i.e.: "Momentum: (%f, %f, %f)" %
-        (XMOM[t_index,0], YMOM[t_index,0], ZMOM[t_index,0]) )</Documentation>
+
+      <!-- BEGIN EXPOSED PROPERTIES -->
+
+      <StringVectorProperty command="SetTimeFormat"
+                            default_values="Date: %b %Y - %I:%M %p"
+                            name="TimeFormat"
+                            label="Date and Time Format"
+                            number_of_elements="1"
+                            panel_visibility="default">
+        <Documentation>Format string according to the datetime class (strftime)
+          for the display of the date.</Documentation>
       </StringVectorProperty>
-      <StringVectorProperty command="GetComputedAnnotationValue"
-                            information_only="1"
-                            name="AnnotationValue">
-        <Documentation>Text that is used as annotation</Documentation>
+
+      <!-- PROPERTIES FROM INHERITED CLASS -->
+
+      <StringVectorProperty command="SetFormat"
+                            default_values=" "
+                            name="Format"
+                            number_of_elements="1"
+                            panel_visibility="never">
+        <Documentation>The value of this property is a format string used to
+        display the input time. The format string is specified using printf
+        style.</Documentation>
       </StringVectorProperty>
+      <DoubleVectorProperty command="SetShift"
+                            default_values="0.0"
+                            name="Shift"
+                            number_of_elements="1"
+                            panel_visibility="never">
+        <DoubleRangeDomain name="range" />
+        <Documentation>The amount of time the input is shifted (after
+        scaling).</Documentation>
+      </DoubleVectorProperty>
+      <DoubleVectorProperty command="SetScale"
+                            default_values="1.0"
+                            name="Scale"
+                            number_of_elements="1"
+                            panel_visibility="never">
+        <DoubleRangeDomain name="range" />
+        <Documentation>The factor by which the input time is
+        scaled.</Documentation>
+      </DoubleVectorProperty>
+
+      <!-- END EXPOSED PROPERTIES -->
+
       <Hints>
         <Visibility replace_input="0" />
         <OutputPort index="0"

--- a/OGSPlugins/OGSAnnotateDateTime/vtkOGSAnnotateDateTime.cxx
+++ b/OGSPlugins/OGSAnnotateDateTime/vtkOGSAnnotateDateTime.cxx
@@ -1,0 +1,68 @@
+/*=========================================================================
+
+  Program:   OGSAnnotateDateTime
+  Module:    vtkOGSAnnotateDateTime.cxx
+
+  Copyright (c) 2018 Arnau Miro, OGS
+  All rights reserved.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "vtkOGSAnnotateDateTime.h"
+
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkDataSet.h"
+#include "vtkFieldData.h"
+#include "vtkStringArray.h"
+
+#include "vtkObjectFactory.h"
+
+#include <ctime>
+
+vtkStandardNewMacro(vtkOGSAnnotateDateTime);
+
+//----------------------------------------------------------------------------
+vtkOGSAnnotateDateTime::vtkOGSAnnotateDateTime()
+{
+	this->TimeFormat = NULL;
+}
+
+//----------------------------------------------------------------------------
+vtkOGSAnnotateDateTime::~vtkOGSAnnotateDateTime()
+{
+	this->SetTimeFormat(0);
+}
+
+//----------------------------------------------------------------------------
+int vtkOGSAnnotateDateTime::RequestData(vtkInformation* request,
+                                        vtkInformationVector** inputVector,
+                                        vtkInformationVector* outputVector)
+{
+
+	// Recover the Date string
+	vtkInformation *inputInfo = inputVector[0]->GetInformationObject(0);
+
+	vtkDataSet *input = vtkDataSet::SafeDownCast(
+		inputInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+	// Recover datevec
+	vtkStringArray *vtkdate = vtkStringArray::SafeDownCast(
+		input->GetFieldData()->GetAbstractArray("Date"));
+
+	// If successful, modify the entry by parsing the string
+	// using the time library
+	if (vtkdate) {
+		struct tm tm;
+		char buff[256];
+		strptime(vtkdate->GetValue(0).c_str(),"%Y%m%d-%H:%M:%S",&tm);
+		strftime(buff,256,this->TimeFormat,&tm);
+		this->Superclass::SetFormat(buff);
+	}
+
+	// Run RequestData from PythonAnnotationFilter
+	return this->Superclass::RequestData(request,inputVector,outputVector);
+}

--- a/OGSPlugins/OGSAnnotateDateTime/vtkOGSAnnotateDateTime.h
+++ b/OGSPlugins/OGSAnnotateDateTime/vtkOGSAnnotateDateTime.h
@@ -1,0 +1,42 @@
+/*=========================================================================
+
+  Program:   OGSAnnotateDateTime
+  Module:    vtkOGSAnnotateDateTime.h
+
+  Copyright (c) 2018 Arnau Miro, OGS
+  All rights reserved.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+
+#ifndef vtkOGSAnnotateDateTime_h
+#define vtkOGSAnnotateDateTime_h
+
+#include "vtkTimeToTextConvertor.h"
+
+class VTK_EXPORT vtkOGSAnnotateDateTime : public vtkTimeToTextConvertor
+{
+public:
+  static vtkOGSAnnotateDateTime* New();
+  vtkTypeMacro(vtkOGSAnnotateDateTime, vtkTimeToTextConvertor);
+
+  vtkSetStringMacro(TimeFormat);
+  vtkGetStringMacro(TimeFormat);
+
+protected:
+  vtkOGSAnnotateDateTime();
+  ~vtkOGSAnnotateDateTime();
+
+  int RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+
+private:
+  vtkOGSAnnotateDateTime(const vtkOGSAnnotateDateTime&) = delete;
+  void operator=(const vtkOGSAnnotateDateTime&) = delete;
+
+  char *TimeFormat;
+};
+
+#endif

--- a/OGSPlugins/OGSHovmoeller/vtkOGSHovmoeller.cxx
+++ b/OGSPlugins/OGSHovmoeller/vtkOGSHovmoeller.cxx
@@ -94,12 +94,6 @@ int vtkOGSHovmoeller::RequestData(vtkInformation *request,
 	// Output is a vtkTable with the interpolated data per each timestep
 	vtkTable *output = vtkTable::SafeDownCast(
 		outInfo->Get(vtkDataObject::DATA_OBJECT()));
-	/*if (!output) {
-		output = vtkTable::New();
-		outInfo->Set(vtkDataObject::DATA_OBJECT(), output);
-		this->GetOutputPortInformation(0)->Set(
-			vtkDataObject::DATA_EXTENT_TYPE(), output->GetExtentType());
-	}*/
 
 	// Check that we can perform the Hovmoeller plot
 	if (this->start_time > this->end_time) {
@@ -162,42 +156,27 @@ int vtkOGSHovmoeller::RequestInformation( vtkInformation *vtkNotUsed(request),
 	vtkInformation *sourceInfo = inputVector[1]->GetInformationObject(0);
 	vtkInformation *outInfo    = outputVector->GetInformationObject(0);
 
-	// Define output as a vtk table
-	/*vtkTable *output = vtkTable::SafeDownCast(
-		outInfo->Get(vtkDataObject::DATA_OBJECT()));
-	if (!output) {
-		output = vtkTable::New();
-		outInfo->Set(vtkDataObject::DATA_OBJECT(), output);
-		this->GetOutputPortInformation(0)->Set(
-			vtkDataObject::DATA_EXTENT_TYPE(), output->GetExtentType());
-	}*/
-
-  	vtkDataSet *source = vtkDataSet::SafeDownCast(
+	vtkDataSet *source = vtkDataSet::SafeDownCast(
 		sourceInfo->Get(vtkDataObject::DATA_OBJECT()));
 
-  	// Recover datevec
-  	vtkStringArray *vtkdatevec = vtkStringArray::SafeDownCast(
-  		source->GetFieldData()->GetAbstractArray("Datevec"));
+	// Recover datevec
+	vtkStringArray *vtkdatevec = vtkStringArray::SafeDownCast(
+		source->GetFieldData()->GetAbstractArray("Datevec"));
 
-  	if (!vtkdatevec) {
-  		vtkErrorMacro("Datevec field array must be loaded!");
-  		int abort = 1;
-  		return 0;
-  	}
+	if (vtkdatevec) {
+		if (this->TimeValues) {
+			this->TimeValues->Delete(); 		
+			this->TimeValues = vtkStringArray::New();
+		}
+		// Set the time data array
+		for(int ii = 0; ii < vtkdatevec->GetNumberOfTuples(); ii++)
+			this->TimeValues->InsertNextValue(vtkdatevec->GetValue(ii));
+	}
 
-  	if (this->TimeValues) {
-  		this->TimeValues->Delete();
-  		this->TimeValues = vtkStringArray::New();
-  	}
-
-  	// Set the time data array
-  	for(int ii = 0; ii < vtkdatevec->GetNumberOfTuples(); ii++)
-  		this->TimeValues->InsertNextValue(vtkdatevec->GetValue(ii));
-
-  	// The output data of this filter has no time associated with it.  It is the
-  	// result of computations that happen over all time.
-  	outInfo->Remove(vtkStreamingDemandDrivenPipeline::TIME_STEPS());
-  	outInfo->Remove(vtkStreamingDemandDrivenPipeline::TIME_RANGE());
+	// The output data of this filter has no time associated with it.  It is the
+	// result of computations that happen over all time.
+	outInfo->Remove(vtkStreamingDemandDrivenPipeline::TIME_STEPS());
+	outInfo->Remove(vtkStreamingDemandDrivenPipeline::TIME_RANGE());
 
 	return 1;
 }

--- a/OGSPlugins/OGSPlotViews/OGSPlotViews.xml
+++ b/OGSPlugins/OGSPlotViews/OGSPlotViews.xml
@@ -573,7 +573,7 @@
                  </Documentation>
                  <Hints>
                    <PropertyWidgetDecorator type="ShowWidgetDecorator">
-                     <Property name="savefigure" function="boolean" />
+                     <Property name="psavefigure" function="boolean" />
                    </PropertyWidgetDecorator>        
                  </Hints>
                </DoubleVectorProperty>

--- a/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.cxx
+++ b/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.cxx
@@ -27,12 +27,10 @@ vtkStandardNewMacro(vtkOGSHovmoellerPlot);
 //----------------------------------------------------------------------------
 vtkOGSHovmoellerPlot::vtkOGSHovmoellerPlot() {
 	this->Script    = NULL;
-	this->Variables = NULL;	
 }
 
 vtkOGSHovmoellerPlot::~vtkOGSHovmoellerPlot() {
 	this->SetScript(NULL);
-	this->SetVariables(NULL);
 }
 
 //----------------------------------------------------------------------------

--- a/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.cxx
+++ b/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.cxx
@@ -40,16 +40,13 @@ void vtkOGSHovmoellerPlot::Update() {
 	// Enable all arrays for plotting
 	this->Superclass::EnableAllAttributeArrays();
 	// First we iterate over the parameters map to create the variable = value pairs
-	char aux1[1024]; strcpy(aux1,"");
+	char aux1[2048]; strcpy(aux1,"");
 	std::map<std::string,std::string>::iterator it;
 	for (it = this->mapParam.begin(); it != mapParam.end(); it++)
 		sprintf(aux1,"%s%s = %s\n",aux1,it->first.c_str(),it->second.c_str());
-	// Second we create an auxiliary string where to store the plot variables
-	char aux2[512];
-	sprintf(aux2,"variables = '''%s'''",this->Variables);
 	// We prepend both strings to the python script
 	std::ostringstream buf;
-	buf << aux1 << "\n" << aux2 << "\n" << this->Script;
+	buf << aux1 << "\n" << this->Script;
 	// Update the Script property of the Superclass with the newly generated script
 	this->Superclass::SetScript(buf.str().c_str());
 	// Finally call the update method of the superclass

--- a/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.h
+++ b/OGSPlugins/OGSPlotViews/vtkOGSHovmoellerPlot.h
@@ -33,12 +33,6 @@ public:
   vtkGetStringMacro(Script);
 
   /*
-    Get/Set the variables.
-  */
-  vtkSetStringMacro(Variables);
-  vtkGetStringMacro(Variables);
-
-  /*
   	Set a name-value parameter that will be available to the script
   	when it is run
   */
@@ -63,7 +57,7 @@ private:
   vtkOGSHovmoellerPlot(const vtkOGSHovmoellerPlot&) =delete;
   void operator=(const vtkOGSHovmoellerPlot&) =delete;
 
-  char *Script, *Variables;
+  char *Script;
   std::map<std::string, std::string> mapParam;
 };
 

--- a/OGSPlugins/OGSPlotViews/vtkOGSVerticalProfilePlot.cxx
+++ b/OGSPlugins/OGSPlotViews/vtkOGSVerticalProfilePlot.cxx
@@ -40,7 +40,7 @@ void vtkOGSVerticalProfilePlot::Update() {
 	// Enable all arrays for plotting
 	this->Superclass::EnableAllAttributeArrays();
 	// First we iterate over the parameters map to create the variable = value pairs
-	char aux1[1024]; strcpy(aux1,"");
+	char aux1[2048]; strcpy(aux1,"");
 	std::map<std::string,std::string>::iterator it;
 	for (it = this->mapParam.begin(); it != mapParam.end(); it++)
 		sprintf(aux1,"%s%s = %s\n",aux1,it->first.c_str(),it->second.c_str());


### PR DESCRIPTION
Fixed heaps and unused variables for the VerticalProfile and Hovmoeller plots.

Major rework in OGSAnnotateDateTime, which now uses the datetime function to parse the date string and format according to user's needs.